### PR TITLE
Add rules to eslint and autofix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,17 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "object-curly-spacing": [
+            "warn",
+            "always"
+        ],
+        "comma-spacing": [
+            "warn",
+            {
+                "before": false,
+                "after": true
+            }
+        ],
         "indent": [
             "error",
             4

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,8 @@
         "sourceType": "module"
     },
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "unused-imports"
     ],
     "rules": {
         "object-curly-spacing": [
@@ -45,9 +46,12 @@
         ],
         "@typescript-eslint/no-non-null-assertion": "off",
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": [
-            "warn"
-        ],
+        "@typescript-eslint/no-unused-vars": "off",
+		"unused-imports/no-unused-imports": "error",
+		"unused-imports/no-unused-vars": [
+			"warn",
+			{ "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
+		],
         "prefer-const": "warn",
         "@typescript-eslint/no-empty-interface": [
             "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@typescript-eslint/parser": "^6.7.5",
         "chai": "^4.3.10",
         "eslint": "^8.51.0",
+        "eslint-plugin-unused-imports": "^3.0.0",
         "jest": "^29.7.0",
         "mocha": "^10.2.0",
         "nodemon": "^3.0.1",
@@ -3363,6 +3364,36 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.0.0.tgz",
+      "integrity": "sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/parser": "^6.7.5",
     "chai": "^4.3.10",
     "eslint": "^8.51.0",
+    "eslint-plugin-unused-imports": "^3.0.0",
     "jest": "^29.7.0",
     "mocha": "^10.2.0",
     "nodemon": "^3.0.1",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,13 +1,12 @@
 import { ConfigHandler } from "./handlers/configHandler";
 import { Client, Collection, Partials, TextChannel, VoiceChannel } from "discord.js";
 import consola, { ConsolaInstance } from "consola";
-import cron, { CronJob } from "cron";
-import { BotConfig, BotEvent, ButtonInteraction, Command } from "../typings";
+import { CronJob } from "cron";
+import { BotEvent, ButtonInteraction, Command } from "../typings";
 import glob from "glob-promise";
-import { promisify } from "util";
 import * as fs from "fs";
 import * as utils from "./utils/utils";
-import {GuildModel} from "./models/guilds";
+import { GuildModel } from "./models/guilds";
 import parser from "yargs-parser";
 import mongoose from "mongoose";
 import path from "path/posix";
@@ -31,7 +30,7 @@ export class Bot extends Client {
     public parser = parser;
     public database = mongoose;
     public readonly initTimestamp = Date.now();
-    public jobs: CronJob<null,null>[] = [];
+    public jobs: CronJob<null, null>[] = [];
     public constructor() {
         super({
             intents: [

--- a/src/commands/admin/decrypttoken.ts
+++ b/src/commands/admin/decrypttoken.ts
@@ -1,10 +1,6 @@
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../typings";
 import "moment-duration-format";
-import {UserModel, User } from "../../models/users";
-import {GuildModel} from "../../models/guilds";
-import { DBRole, InternalRoles, RoleScopes } from "../../models/bot_roles";
-import { Types } from "mongoose";
 
 
 
@@ -37,7 +33,7 @@ const command: Command = {
         } catch (error) {
             return await client.utils.embeds.SimpleEmbed(interaction, { title: "Verification System Error", text: "Token is not valid.", empheral: true });
         }
-        return client.utils.embeds.SimpleEmbed(interaction, { title: "Decrypted Text", text: `decrypted: ${decrypted}`, empheral:true});
+        return client.utils.embeds.SimpleEmbed(interaction, { title: "Decrypted Text", text: `decrypted: ${decrypted}`, empheral:true });
     },
 };
 

--- a/src/commands/admin/fixverify.ts
+++ b/src/commands/admin/fixverify.ts
@@ -1,8 +1,8 @@
 import { Message, Role } from "discord.js";
 import { Command } from "../../../typings";
 import "moment-duration-format";
-import {UserModel, User } from "../../models/users";
-import {GuildModel} from "../../models/guilds";
+import { UserModel } from "../../models/users";
+import { GuildModel } from "../../models/guilds";
 import { DBRole, InternalRoles, RoleScopes } from "../../models/bot_roles";
 import { Types } from "mongoose";
 import { DocumentType } from "@typegoose/typegoose";

--- a/src/commands/admin/generatetoken.ts
+++ b/src/commands/admin/generatetoken.ts
@@ -28,7 +28,7 @@ const command: Command = {
         }
         const encrypted = client.utils.general.encryptText(interaction.options.getString("encryptionstring", true));
         const decrypted = client.utils.general.decryptText(encrypted);
-        return client.utils.embeds.SimpleEmbed(interaction, { title: "Encrypted+Decrypted Text", text: `encrypted: ${encrypted}\ndecrypted: ${decrypted}`, empheral:true});
+        return client.utils.embeds.SimpleEmbed(interaction, { title: "Encrypted+Decrypted Text", text: `encrypted: ${encrypted}\ndecrypted: ${decrypted}`, empheral:true });
     },
 };
 

--- a/src/commands/admin/genverifyroles.ts
+++ b/src/commands/admin/genverifyroles.ts
@@ -1,10 +1,9 @@
 import { Message, Role } from "discord.js";
 import { Command } from "../../../typings";
 import "moment-duration-format";
-import {UserModel, User } from "../../models/users";
-import {GuildModel} from "../../models/guilds";
+import { GuildModel } from "../../models/guilds";
 import { DBRole, InternalRoles, RoleScopes } from "../../models/bot_roles";
-import { ArraySubDocumentType, DocumentType, mongoose } from "@typegoose/typegoose";
+import { ArraySubDocumentType, mongoose } from "@typegoose/typegoose";
 
 
 

--- a/src/commands/admin/member/lookup-by.ts
+++ b/src/commands/admin/member/lookup-by.ts
@@ -1,10 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
-import moment from "moment";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel, User } from "../../../models/users";
-import {SessionModel} from "../../../models/sessions";
-import {QueueModel} from "../../../models/queues";
+import { UserModel, User } from "../../../models/users";
 import { FilterQuery } from "mongoose";
 import { DocumentType, mongoose } from "@typegoose/typegoose";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";

--- a/src/commands/admin/member/lookup.ts
+++ b/src/commands/admin/member/lookup.ts
@@ -1,10 +1,6 @@
-import { ApplicationCommandOptionType, EmbedData, EmbedField, Message } from "discord.js";
-import moment from "moment";
+import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {SessionModel} from "../../../models/sessions";
-import {QueueModel} from "../../../models/queues";
+import { UserModel } from "../../../models/users";
 
 const command: Command = {
     name: "lookup",

--- a/src/commands/admin/member/unverify.ts
+++ b/src/commands/admin/member/unverify.ts
@@ -1,10 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
-import moment from "moment";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {SessionModel} from "../../../models/sessions";
-import {QueueModel} from "../../../models/queues";
+import { UserModel } from "../../../models/users";
 
 const command: Command = {
     name: "unverify",

--- a/src/commands/admin/queue/fixup.ts
+++ b/src/commands/admin/queue/fixup.ts
@@ -1,8 +1,7 @@
-import { ApplicationCommandOptionType, EmbedField, Message, Role } from "discord.js";
-import path from "path";
+import { ApplicationCommandOptionType, Message, Role } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
 
 const command: Command = {
     name: "fixup",

--- a/src/commands/admin/queue/info.ts
+++ b/src/commands/admin/queue/info.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "info",

--- a/src/commands/admin/queue/kick.ts
+++ b/src/commands/admin/queue/kick.ts
@@ -1,8 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "kick",

--- a/src/commands/admin/queue/list.ts
+++ b/src/commands/admin/queue/list.ts
@@ -1,8 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "list",

--- a/src/commands/admin/queue/lock.ts
+++ b/src/commands/admin/queue/lock.ts
@@ -1,8 +1,6 @@
-import { ApplicationCommandOptionType, EmbedField, Message, VoiceChannel } from "discord.js";
-import path from "path";
+import { ApplicationCommandOptionType, Message, VoiceChannel } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "lock",

--- a/src/commands/admin/queue/unlock.ts
+++ b/src/commands/admin/queue/unlock.ts
@@ -1,8 +1,6 @@
-import { ApplicationCommandOptionType, EmbedField, Message, VoiceChannel } from "discord.js";
-import path from "path";
+import { ApplicationCommandOptionType, Message, VoiceChannel } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "unlock",

--- a/src/commands/admin/queue/userrank.ts
+++ b/src/commands/admin/queue/userrank.ts
@@ -1,9 +1,8 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {RoomModel} from "../../../models/rooms";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
+import { RoomModel } from "../../../models/rooms";
 
 const command: Command = {
     name: "userrank",
@@ -75,7 +74,7 @@ const command: Command = {
                     inline: false,
                 });
             } catch (error) {
-                client.logger.error(`could not get user details for ${u._id}`,error);
+                client.logger.error(`could not get user details for ${u._id}`, error);
                 fields.push({
                     name: u._id, value:
                     `-Sprechstunden Beigetreten: ${u.roomCount}`,

--- a/src/commands/admin/queue/userstats.ts
+++ b/src/commands/admin/queue/userstats.ts
@@ -1,9 +1,7 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {RoomModel} from "../../../models/rooms";
+import { GuildModel } from "../../../models/guilds";
+import { RoomModel } from "../../../models/rooms";
 
 const command: Command = {
     name: "userstats",

--- a/src/commands/admin/serverstats.ts
+++ b/src/commands/admin/serverstats.ts
@@ -1,10 +1,7 @@
-import { ApplicationCommandOptionType, AttachmentBuilder, AuditLogEvent, Collection, GuildAuditLogs, GuildAuditLogsEntry, Message } from "discord.js";
+import { ApplicationCommandOptionType, AttachmentBuilder, AuditLogEvent, Collection, GuildAuditLogsEntry, Message } from "discord.js";
 import { Command } from "../../../typings";
-import { version as djsversion } from "discord.js";
-import * as moment from "moment";
 import "moment-duration-format";
 import { ChartJSNodeCanvas } from "chartjs-node-canvas";
-import { string } from "yargs";
 import { APIRole } from "discord-api-types/v9";
 
 
@@ -172,7 +169,7 @@ const command: Command = {
                 },
             },
         );
-        const attachment = new AttachmentBuilder(image, {name: "graph.png"});
+        const attachment = new AttachmentBuilder(image, { name: "graph.png" });
         await client.utils.embeds.SimpleEmbed(interaction, {
             title: "Server Stats",
             text: "Server Information",

--- a/src/commands/admin/session/list.ts
+++ b/src/commands/admin/session/list.ts
@@ -1,10 +1,7 @@
 import { EmbedField, Message } from "discord.js";
-import moment from "moment";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {SessionModel} from "../../../models/sessions";
-import {QueueModel} from "../../../models/queues";
+import { GuildModel } from "../../../models/guilds";
+import { SessionModel } from "../../../models/sessions";
 
 const command: Command = {
     name: "list",

--- a/src/commands/admin/session/terminate.ts
+++ b/src/commands/admin/session/terminate.ts
@@ -1,10 +1,8 @@
-import { ApplicationCommandOptionType, EmbedField, GuildMember, Message, User } from "discord.js";
+import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {SessionModel} from "../../../models/sessions";
-import {QueueModel} from "../../../models/queues";
+import { GuildModel } from "../../../models/guilds";
+import { SessionModel } from "../../../models/sessions";
 
 const command: Command = {
     name: "terminate",

--- a/src/commands/admin/session/terminateall.ts
+++ b/src/commands/admin/session/terminateall.ts
@@ -1,10 +1,8 @@
-import { EmbedField, GuildMember, Message, User } from "discord.js";
+import { EmbedField, Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {SessionModel} from "../../../models/sessions";
-import {QueueModel} from "../../../models/queues";
+import { GuildModel } from "../../../models/guilds";
+import { SessionModel } from "../../../models/sessions";
 
 const command: Command = {
     name: "terminateall",

--- a/src/commands/coach/info.ts
+++ b/src/commands/coach/info.ts
@@ -1,8 +1,8 @@
 import { Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import {UserModel} from "../../models/users";
+import { GuildModel } from "../../models/guilds";
+import { UserModel } from "../../models/users";
 
 const command: Command = {
     name: "info",

--- a/src/commands/coach/queue/info.ts
+++ b/src/commands/coach/queue/info.ts
@@ -1,7 +1,7 @@
 import { Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
 
 const command: Command = {
     name: "info",

--- a/src/commands/coach/queue/list.ts
+++ b/src/commands/coach/queue/list.ts
@@ -1,8 +1,7 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
 
 const command: Command = {
     name: "list",

--- a/src/commands/coach/queue/next.ts
+++ b/src/commands/coach/queue/next.ts
@@ -1,10 +1,10 @@
-import {EventModel, Event as EVT, eventType } from "./../../../models/events";
+import { Event as EVT, eventType } from "./../../../models/events";
 import { PermissionOverwriteData } from "./../../../models/permission_overwrite_data";
 import ChannelType, { ApplicationCommandOptionType, Message, TextChannel } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {RoomModel} from "../../../models/rooms";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
+import { RoomModel } from "../../../models/rooms";
 import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
 import { mongoose } from "@typegoose/typegoose";
 

--- a/src/commands/coach/queue/pick.ts
+++ b/src/commands/coach/queue/pick.ts
@@ -1,11 +1,11 @@
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
-import {EventModel, Event as EVT, eventType } from "../../../models/events";
+import { Event as EVT, eventType } from "../../../models/events";
 import { PermissionOverwriteData } from "../../../models/permission_overwrite_data";
 import ChannelType, { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {RoomModel} from "../../../models/rooms";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
+import { RoomModel } from "../../../models/rooms";
 import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
 import { mongoose } from "@typegoose/typegoose";
 

--- a/src/commands/coach/session/info.ts
+++ b/src/commands/coach/session/info.ts
@@ -1,8 +1,8 @@
 import { Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
 
 const command: Command = {
     name: "info",

--- a/src/commands/coach/session/quit.ts
+++ b/src/commands/coach/session/quit.ts
@@ -1,7 +1,7 @@
 import { Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
 import moment from "moment";
 
 const command: Command = {

--- a/src/commands/coach/session/start.ts
+++ b/src/commands/coach/session/start.ts
@@ -1,8 +1,8 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import {UserModel} from "../../../models/users";
-import {SessionModel, sessionRole } from "../../../models/sessions";
+import { GuildModel } from "../../../models/guilds";
+import { UserModel } from "../../../models/users";
+import { SessionModel, sessionRole } from "../../../models/sessions";
 import { Queue } from "../../../models/queues";
 import { DocumentType } from "@typegoose/typegoose";
 

--- a/src/commands/config/commands/permission.ts
+++ b/src/commands/config/commands/permission.ts
@@ -1,7 +1,7 @@
 import { SlashCommandPermission } from "./../../../models/slash_command_permission";
 import { ApplicationCommandOptionType, Message, Role } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "permission",

--- a/src/commands/config/commands/rename.ts
+++ b/src/commands/config/commands/rename.ts
@@ -1,8 +1,6 @@
-import { SlashCommandSettings } from "./../../../models/slash_command_settings";
 import { ApplicationCommandOptionType, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "rename",

--- a/src/commands/config/commands/visibility.ts
+++ b/src/commands/config/commands/visibility.ts
@@ -1,8 +1,6 @@
-import { SlashCommandSettings } from "./../../../models/slash_command_settings";
 import { ApplicationCommandOptionType, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "visibility",

--- a/src/commands/config/queue/add_unlock_time.ts
+++ b/src/commands/config/queue/add_unlock_time.ts
@@ -1,8 +1,6 @@
-import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
+import { GuildModel } from "../../../models/guilds";
 import { QueueSpan } from "../../../models/queue_span";
 
 const command: Command = {

--- a/src/commands/config/queue/autolock.ts
+++ b/src/commands/config/queue/autolock.ts
@@ -1,6 +1,4 @@
-import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
 import { GuildModel } from "../../../models/guilds";
 

--- a/src/commands/config/queue/get_schedules.ts
+++ b/src/commands/config/queue/get_schedules.ts
@@ -1,8 +1,6 @@
-import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
+import { GuildModel } from "../../../models/guilds";
 import { QueueSpan } from "../../../models/queue_span";
 import { WeekTimestamp } from "../../../models/week_timestamp";
 

--- a/src/commands/config/queue/remove_unlock_time.ts
+++ b/src/commands/config/queue/remove_unlock_time.ts
@@ -1,8 +1,6 @@
-import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
+import { GuildModel } from "../../../models/guilds";
 import { QueueSpan } from "../../../models/queue_span";
 import { WeekTimestamp } from "../../../models/week_timestamp";
 

--- a/src/commands/config/queue/set_category.ts
+++ b/src/commands/config/queue/set_category.ts
@@ -1,9 +1,8 @@
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
 import { VoiceChannelSpawner } from "./../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "./../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
+import { GuildModel } from "../../../models/guilds";
 import { mongoose } from "@typegoose/typegoose";
 
 const command: Command = {

--- a/src/commands/config/queue/set_closing_shift.ts
+++ b/src/commands/config/queue/set_closing_shift.ts
@@ -1,9 +1,6 @@
-import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import { QueueSpan } from "../../../models/queue_span";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "set_closing_shift",

--- a/src/commands/config/queue/set_opening_shift.ts
+++ b/src/commands/config/queue/set_opening_shift.ts
@@ -1,9 +1,6 @@
-import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import { QueueSpan } from "../../../models/queue_span";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "set_opening_shift",

--- a/src/commands/config/queue/set_text_channel.ts
+++ b/src/commands/config/queue/set_text_channel.ts
@@ -1,10 +1,6 @@
-import { Channel } from "./../../../models/text_channels";
-import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
-import { SlashCommandPermission } from "../../../models/slash_command_permission";
-import { ApplicationCommandOptionType, Message, Role } from "discord.js";
+import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import {GuildModel} from "../../../models/guilds";
-import { QueueSpan } from "../../../models/queue_span";
+import { GuildModel } from "../../../models/guilds";
 
 const command: Command = {
     name: "set_text_channel",

--- a/src/commands/create-queue.ts
+++ b/src/commands/create-queue.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../typings";
-import {GuildModel} from "../models/guilds";
+import { GuildModel } from "../models/guilds";
 import { Queue } from "../models/queues";
 import { mongoose } from "@typegoose/typegoose";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType, EmojiIdentifierResolvable, Message, EmbedBuilder } from "discord.js";
 import yargsParser from "yargs-parser";
-import { Command, RunCommand } from "../../typings";
-import {GuildModel} from "../models/guilds";
+import { Command } from "../../typings";
+import { GuildModel } from "../models/guilds";
 
 
 const command: Command = {

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,6 +1,5 @@
-import { ChatInputCommandInteraction, Interaction, Message, EmbedBuilder } from "discord.js";
-import { Command, RunCommand } from "../../typings";
-import { APIMessage } from "discord-api-types/v9";
+import { ChatInputCommandInteraction, Message, EmbedBuilder } from "discord.js";
+import { Command } from "../../typings";
 
 /**
  * The Command Definition
@@ -30,8 +29,8 @@ const command: Command = {
         const embed = new EmbedBuilder()
             .setTitle("__Response Times__")
             .setColor(interaction!.guild?.members.me?.roles.highest.color || 0x7289da)
-            .addFields({name:"Bot Latency:", value:":hourglass_flowing_sand:" + ping + "ms", inline:true})
-            .addFields({name:"API Latency:", value:":hourglass_flowing_sand:" + Math.round(client.ws.ping) + "ms", inline:true});
+            .addFields({ name:"Bot Latency:", value:":hourglass_flowing_sand:" + ping + "ms", inline:true })
+            .addFields({ name:"API Latency:", value:":hourglass_flowing_sand:" + Math.round(client.ws.ping) + "ms", inline:true });
         if (interaction instanceof ChatInputCommandInteraction) {
             await interaction.editReply({ content: "Pong.", embeds: [embed] });
         } else {

--- a/src/commands/queue/info.ts
+++ b/src/commands/queue/info.ts
@@ -1,6 +1,6 @@
 import { Message, EmbedField } from "discord.js";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "info",

--- a/src/commands/queue/join.ts
+++ b/src/commands/queue/join.ts
@@ -1,8 +1,7 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
-import path from "path";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import {UserModel} from "../../models/users";
+import { GuildModel } from "../../models/guilds";
+import { UserModel } from "../../models/users";
 
 const command: Command = {
     name: "join",

--- a/src/commands/queue/leave.ts
+++ b/src/commands/queue/leave.ts
@@ -1,8 +1,6 @@
 import { Message } from "discord.js";
-import moment from "moment";
-import path from "path";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "leave",

--- a/src/commands/queue/list.ts
+++ b/src/commands/queue/list.ts
@@ -1,7 +1,6 @@
-import { Queue } from "./../../models/queues";
 import { Message } from "discord.js";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "list",

--- a/src/commands/rate.ts
+++ b/src/commands/rate.ts
@@ -1,5 +1,5 @@
-import { ApplicationCommandOptionType, ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
-import { Command, RunCommand } from "../../typings";
+import { ApplicationCommandOptionType, ChatInputCommandInteraction } from "discord.js";
+import { Command } from "../../typings";
 
 /**
  * The Command Definition

--- a/src/commands/setjointocreate.ts
+++ b/src/commands/setjointocreate.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, CategoryChannel, GuildChannel, Message, VoiceChannel as dvc } from "discord.js";
 import { Command } from "../../typings";
-import {GuildModel} from "../models/guilds";
+import { GuildModel } from "../models/guilds";
 import { VoiceChannel } from "../models/voice_channels";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
 import { mongoose } from "@typegoose/typegoose";

--- a/src/commands/setqueue.ts
+++ b/src/commands/setqueue.ts
@@ -1,7 +1,7 @@
 import { VoiceChannelModel } from "./../models/voice_channels";
 import { ApplicationCommandOptionType, GuildChannel, Message } from "discord.js";
 import { Command } from "../../typings";
-import {GuildModel} from "../models/guilds";
+import { GuildModel } from "../models/guilds";
 import { VoiceChannel } from "../models/voice_channels";
 import { mongoose } from "@typegoose/typegoose";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";

--- a/src/commands/urban.ts
+++ b/src/commands/urban.ts
@@ -1,7 +1,7 @@
 import { stripIndents } from "common-tags";
 import * as urban from "urban-dictionary";
-import { ApplicationCommandOptionType, ChatInputCommandInteraction, Interaction, Message, EmbedBuilder } from "discord.js";
-import { Command, RunCommand } from "../../typings";
+import { ApplicationCommandOptionType, ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import { Command } from "../../typings";
 
 /**
  * The Command Definition

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,7 +1,5 @@
-import { UserModel, User } from "./../models/users";
-import { ApplicationCommandOptionType, GuildMember, Interaction, Message } from "discord.js";
-import { Command, RunCommand } from "../../typings";
-import * as crypto from "crypto";
+import { ApplicationCommandOptionType, Message } from "discord.js";
+import { Command } from "../../typings";
 
 /**
  * The Command Definition

--- a/src/commands/voice/close.ts
+++ b/src/commands/voice/close.ts
@@ -1,7 +1,6 @@
 import { Message } from "discord.js";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "close",

--- a/src/commands/voice/kick.ts
+++ b/src/commands/voice/kick.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, GuildMember, Message } from "discord.js";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "kick",

--- a/src/commands/voice/lock.ts
+++ b/src/commands/voice/lock.ts
@@ -1,6 +1,5 @@
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "lock",

--- a/src/commands/voice/permit.ts
+++ b/src/commands/voice/permit.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, GuildMember, Message } from "discord.js";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "permit",

--- a/src/commands/voice/togglelock.ts
+++ b/src/commands/voice/togglelock.ts
@@ -1,7 +1,6 @@
 import { OverwriteData } from "discord.js";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "togglelock",

--- a/src/commands/voice/togglevisibility.ts
+++ b/src/commands/voice/togglevisibility.ts
@@ -1,6 +1,5 @@
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "togglevisibility",

--- a/src/commands/voice/transfer.ts
+++ b/src/commands/voice/transfer.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, GuildMember, Message } from "discord.js";
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "transfer",

--- a/src/commands/voice/unlock.ts
+++ b/src/commands/voice/unlock.ts
@@ -1,6 +1,5 @@
 import { Command } from "../../../typings";
-import {GuildModel} from "../../models/guilds";
-import { VoiceChannel } from "../../models/voice_channels";
+import { GuildModel } from "../../models/guilds";
 
 const command: Command = {
     name: "unlock",

--- a/src/componentInteractions/buttons/queue/leave.ts
+++ b/src/componentInteractions/buttons/queue/leave.ts
@@ -1,4 +1,4 @@
-import { Collection, EmbedBuilder } from "discord.js";
+import { EmbedBuilder } from "discord.js";
 import { ButtonInteraction } from "../../../../typings";
 import { GuildModel, Guild } from "../../../models/guilds";
 import { Queue } from "../../../models/queues";

--- a/src/componentInteractions/buttons/queue/stay.ts
+++ b/src/componentInteractions/buttons/queue/stay.ts
@@ -1,6 +1,6 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Collection, EmbedBuilder } from "discord.js";
 import { ButtonInteraction } from "../../../../typings";
-import {GuildModel, Guild } from "../../../models/guilds";
+import { GuildModel, Guild } from "../../../models/guilds";
 import { Queue } from "../../../models/queues";
 import { DocumentType } from "@typegoose/typegoose";
 

--- a/src/events/GuildCreateEvent.ts
+++ b/src/events/GuildCreateEvent.ts
@@ -1,7 +1,5 @@
-import { ClientEventListener, ExecuteEvent } from "../../typings";
-import { ApplicationCommandData, ApplicationCommandOptionChoiceData, Client, ClientEvents, Guild } from "discord.js";
-import {GuildModel} from "../models/guilds";
-import { inspect } from "util";
+import { ExecuteEvent } from "../../typings";
+import { GuildModel } from "../models/guilds";
 
 export const name = "guildCreate";
 

--- a/src/events/InteractionCreateEvent.ts
+++ b/src/events/InteractionCreateEvent.ts
@@ -1,9 +1,7 @@
-import { Command, ExecuteEvent } from "../../typings";
-import { ChatInputCommandInteraction, Collection, CommandInteractionOption } from "discord.js";
+import { ExecuteEvent } from "../../typings";
+import { ChatInputCommandInteraction, Collection } from "discord.js";
 export const name = "interactionCreate";
-import {GuildModel} from "../models/guilds";
-import { DocumentType, isDocument } from "@typegoose/typegoose";
-import { GuildSettings } from "../models/guild_settings";
+import { GuildModel } from "../models/guilds";
 
 export const execute: ExecuteEvent<"interactionCreate"> = async (client, interaction) => {
 

--- a/src/events/MessageCreateEvent.ts
+++ b/src/events/MessageCreateEvent.ts
@@ -1,8 +1,6 @@
 import { ExecuteEvent } from "../../typings";
-import { Collection, Guild, GuildMember, Message } from "discord.js";
+import { Collection } from "discord.js";
 export const name = "messageCreate";
-import * as crypto from "crypto";
-import {UserModel} from "../models/users";
 
 export const execute: ExecuteEvent<"messageCreate"> = async (client, message) => {
     if (message.partial) {

--- a/src/events/ReadyEvent.ts
+++ b/src/events/ReadyEvent.ts
@@ -1,6 +1,6 @@
 import { ExecuteEvent } from "../../typings";
 import { ActivityType, ApplicationCommandData } from "discord.js";
-import {GuildModel} from "../models/guilds";
+import { GuildModel } from "../models/guilds";
 
 export const execute: ExecuteEvent<"ready"> = async (client) => {
     // -- Setup Databases -- //
@@ -27,7 +27,7 @@ export const execute: ExecuteEvent<"ready"> = async (client) => {
     // Guilds
     client.logger.info("Processing Guilds");
     for (const g of [...client.guilds.cache.values()]) {
-        await GuildModel.prepareGuild(client,g);
+        await GuildModel.prepareGuild(client, g);
     }
 
     await client.user?.setPresence({ status: "online", activities: [{ name: "Sprechstunden.", type: ActivityType.Watching }], afk: false });

--- a/src/events/VoiceStateUpdateEvent.ts
+++ b/src/events/VoiceStateUpdateEvent.ts
@@ -1,13 +1,10 @@
 import { ExecuteEvent } from "../../typings";
-import { Collection, ActionRow, Embed, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, APIMessageActionRowComponent } from "discord.js";
-import {GuildModel} from "../models/guilds";
-import { VoiceChannel } from "../models/voice_channels";
-import { Queue } from "../models/queues";
+import { Collection, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from "discord.js";
+import { GuildModel } from "../models/guilds";
 import { QueueEntry } from "../models/queue_entry";
 export const name = "voiceStateUpdate";
-import {RoomModel} from "../models/rooms";
-import {UserModel} from "../models/users";
-import {EventModel, Event as EVT, eventType } from "../models/events";
+import { RoomModel } from "../models/rooms";
+import { Event as EVT, eventType } from "../models/events";
 
 export const execute: ExecuteEvent<"voiceStateUpdate"> = async (client, oldState, newState) => {
     const oldUserChannel = oldState.channel;

--- a/src/events/guildMemberAddEvent.ts
+++ b/src/events/guildMemberAddEvent.ts
@@ -1,8 +1,6 @@
-import { ClientEventListener, ExecuteEvent, StringReplacements } from "../../typings";
-import { ApplicationCommandData, ApplicationCommandOptionChoiceData, Client, ClientEvents, Guild } from "discord.js";
-import {GuildModel} from "../models/guilds";
-import {UserModel} from "../models/users";
-import { inspect } from "util";
+import { ExecuteEvent, StringReplacements } from "../../typings";
+import { GuildModel } from "../models/guilds";
+import { UserModel } from "../models/users";
 
 export const name = "guildMemberAdd";
 

--- a/src/events/guildMemberRemoveEvent.ts
+++ b/src/events/guildMemberRemoveEvent.ts
@@ -1,5 +1,5 @@
 import { ExecuteEvent } from "../../typings";
-import {UserModel} from "../models/users";
+import { UserModel } from "../models/users";
 
 export const name = "guildMemberRemove";
 

--- a/src/handlers/configHandler.ts
+++ b/src/handlers/configHandler.ts
@@ -1,5 +1,4 @@
 import { BotConfig } from "../../typings";
-import dotenv from "dotenv";
 
 /**
  * This is a readonly data class that holds the config of the bot.

--- a/src/models/database_mockup.ts
+++ b/src/models/database_mockup.ts
@@ -18,10 +18,10 @@ const sessions =
             active: true,
             user: "313753317484527616",
             guild: "604601483920408576",
-            queue: "queue_id",//optional
+            queue: "queue_id", //optional
             role: "coach", // participant|coach|supervisor
             started_at: "1629567410185",
-            ended_at: undefined,//Set when active=false
+            ended_at: undefined, //Set when active=false
             end_certain: false, // Only set to true if session had a clean exit
             rooms: ["626065226986553343", "626065222936553347"],
         },

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -23,27 +23,27 @@ export class Event {
     /**
      * The Unix Time Stamp of the Event
      */
-    @prop({required: true})
+    @prop({ required: true })
         timestamp!: string;
     /**
      * The Event Type
      */
-    @prop({required: true, enum: eventType, default: eventType.other})
+    @prop({ required: true, enum: eventType, default: eventType.other })
         type!: eventType;
     /**
      * Client ID or "me"
      */
-    @prop({required: true})
+    @prop({ required: true })
         emitted_by!: string;
     /**
      * A Target that was affected
      */
-    @prop({required: false})
+    @prop({ required: false })
         target?: string;
     /**
      * The Reason why the Event was Emitted
      */
-    @prop({required: false})
+    @prop({ required: false })
         reason?: string;
 }
 

--- a/src/models/queues.ts
+++ b/src/models/queues.ts
@@ -4,7 +4,6 @@ import { QueueEntry } from "./queue_entry";
 import * as utils from "../utils/utils";
 import { StringReplacements } from "../../typings";
 import * as moment from "moment";
-import momentDurationFormatSetup from "moment-duration-format";
 import { QueueSpan } from "./queue_span";
 import { Guild } from "./guilds";
 import { VoiceChannelSpawner } from "./voice_channel_spawner";
@@ -146,7 +145,7 @@ export class Queue {
      * Returns true if the ID is contained in the queue
      * @param discord_id the Discord ID to check if it's contained
      */
-    public contains(this:DocumentType<Queue>,discord_id: string): boolean {
+    public contains(this:DocumentType<Queue>, discord_id: string): boolean {
         return this.entries.some(x => x.discord_id === discord_id);
     }
     /**

--- a/src/models/sessions.ts
+++ b/src/models/sessions.ts
@@ -1,5 +1,5 @@
-import {RoomModel} from "./rooms";
-import {DocumentType, getModelForClass, prop, mongoose} from "@typegoose/typegoose";
+import { RoomModel } from "./rooms";
+import { DocumentType, getModelForClass, prop, mongoose } from "@typegoose/typegoose";
 export enum sessionRole {
     "participant" = "participant",
     "coach" = "coach",
@@ -10,12 +10,12 @@ export class Session {
     /**
      * Whether the Session is currently active
      */
-    @prop({required: true})
+    @prop({ required: true })
         active!: boolean;
     /**
      * The User that the Session belongs to
      */
-    @prop({required: true})
+    @prop({ required: true })
         user!: string;
     /**
      * A Guild that the Session belongs to
@@ -30,7 +30,7 @@ export class Session {
     /**
      *  The Role that the user plays
      */
-    @prop({required: true, enum: sessionRole})
+    @prop({ required: true, enum: sessionRole })
         role!: sessionRole;
     /**
      * The Start Timestamp
@@ -45,12 +45,12 @@ export class Session {
     /**
      * Only set to true if session had a clean exit
      */
-    @prop({required: true})
+    @prop({ required: true })
         end_certain!: boolean;
     /**
      * The Room IDs That Were Visited in the Session
      */
-    @prop({required: true, type: () => [String], default: []})
+    @prop({ required: true, type: () => [String], default: [] })
         rooms!: mongoose.Types.Array<string>;
 
     /**

--- a/src/models/slash_command_settings.ts
+++ b/src/models/slash_command_settings.ts
@@ -1,11 +1,11 @@
 import { SlashCommandPermission } from "./slash_command_permission";
 import { PermissionResolvable } from "discord.js";
-import { ArraySubDocumentType, SubDocumentType, getModelForClass, prop, mongoose } from "@typegoose/typegoose";
+import { ArraySubDocumentType, getModelForClass, prop, mongoose } from "@typegoose/typegoose";
 export class SlashCommandSettings {
     /**
      * The original Command name used to retrieve it from the event handler
      */
-    @prop({ required: true,sparse: true })
+    @prop({ required: true, sparse: true })
         internal_name!: string;
     /**
      * The Command Name overwrite

--- a/src/models/text_channels.ts
+++ b/src/models/text_channels.ts
@@ -1,5 +1,5 @@
 import { ChannelType, TextChannelType } from "discord.js";
-import {getModelForClass, prop} from "@typegoose/typegoose";
+import { getModelForClass, prop } from "@typegoose/typegoose";
 
 /**
  * Database Representation of a Discord Channel
@@ -28,9 +28,9 @@ export interface Channel {
 }
 
 export class TextChannel implements Channel {
-    @prop({required: true})
+    @prop({ required: true })
         _id!: string;
-    @prop({ required: true, type: Number, enum: [ChannelType.DM, ChannelType.GroupDM, ChannelType.GuildAnnouncement, ChannelType.PublicThread, ChannelType.PrivateThread, ChannelType.AnnouncementThread, ChannelType.GuildText, ChannelType.GuildForum, ChannelType.GuildVoice, ChannelType.GuildStageVoice]})
+    @prop({ required: true, type: Number, enum: [ChannelType.DM, ChannelType.GroupDM, ChannelType.GuildAnnouncement, ChannelType.PublicThread, ChannelType.PrivateThread, ChannelType.AnnouncementThread, ChannelType.GuildText, ChannelType.GuildForum, ChannelType.GuildVoice, ChannelType.GuildStageVoice] })
         channel_type!: TextChannelType;
     @prop({ required: true })
         managed!: boolean;
@@ -51,7 +51,7 @@ export class TextChannel implements Channel {
     /**
      * WHETHER THE CHANNEL IS CAPS-ONLY
      */
-    @prop({default: false})
+    @prop({ default: false })
         rage_channel?: boolean;
 }
 

--- a/src/models/voice_channel_spawner.ts
+++ b/src/models/voice_channel_spawner.ts
@@ -1,5 +1,5 @@
 import { PermissionOverwriteData } from "./permission_overwrite_data";
-import {prop,mongoose, getModelForClass, ArraySubDocumentType} from "@typegoose/typegoose";
+import { prop, mongoose, getModelForClass, ArraySubDocumentType } from "@typegoose/typegoose";
 
 export class VoiceChannelSpawner {
     /**
@@ -10,12 +10,12 @@ export class VoiceChannelSpawner {
     /**
      * The Roles that can moderate this channel
      */
-    @prop({required: true, type: () => [String], default: []})
+    @prop({ required: true, type: () => [String], default: [] })
         supervisor_roles!: mongoose.Types.Array<string>;
     /**
      * The Channel Permissions
      */
-    @prop({required: true, type: () => [PermissionOverwriteData], default: []})
+    @prop({ required: true, type: () => [PermissionOverwriteData], default: [] })
         permission_overwrites!: mongoose.Types.DocumentArray<ArraySubDocumentType<PermissionOverwriteData>>;
     /**
      * Limit the amount of Users that can join the channel
@@ -25,17 +25,17 @@ export class VoiceChannelSpawner {
     /**
      * The Name of the Channel; use ${owner} and so on to create dynamic channel names
      */
-    @prop({required: true, default: "${owner_name}'s VC"})
+    @prop({ required: true, default: "${owner_name}'s VC" })
         name!: string;
     /**
      * Whether the Channel should initially be locked or not
      */
-    @prop({default: false})
+    @prop({ default: false })
         lock_initially?: boolean;
     /**
      * Whether the Channel should initially be hidden or not
      */
-    @prop({default: false})
+    @prop({ default: false })
         hide_initially?: boolean;
     /**
      * The Category Channel ID

--- a/src/models/week_timestamp.ts
+++ b/src/models/week_timestamp.ts
@@ -39,7 +39,7 @@ export class WeekTimestamp {
     /**
      * The Day of the Week
      */
-    @prop({ required: true,enum: Weekday })
+    @prop({ required: true, enum: Weekday })
         weekday!: Weekday;
 
     /**

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -1,6 +1,4 @@
-import { ColorResolvable, CommandInteraction, DMChannel, Guild, GuildResolvable, Interaction, InteractionReplyOptions, Message, Embed, NewsChannel, PartialDMChannel, TextBasedChannel, TextChannel, ThreadChannel, UserResolvable, EmbedBuilder, InteractionResponse } from "discord.js";
-import { APIMessage } from "discord-api-types/v9";
-import * as utils from "./utils";
+import { CommandInteraction, DMChannel, Message, NewsChannel, TextChannel, ThreadChannel, EmbedBuilder, InteractionResponse } from "discord.js";
 import { SimpleEmbedOptions } from "../../typings";
 
 export async function SimpleEmbed(interaction: Message | CommandInteraction | DMChannel | TextChannel | NewsChannel | ThreadChannel, title: string, description: string): Promise<Message | null>;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,5 @@
-import { DiscordAPIError, Message, EmbedBuilder } from "discord.js";
+import { Message, EmbedBuilder } from "discord.js";
 import * as discord from "discord.js";
-import { APIMessage } from "discord-api-types/v9";
 // : (message: Message, error: string, deleteinterval: number => Promise<Message>)
 export const errorMessage = async (interaction: Message | discord.CommandInteraction, error: string | Error, deleteinterval?: number) => {
     if (!interaction.channel) {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -3,11 +3,9 @@ import { DBRole, InternalRoles, RoleScopes } from "./../models/bot_roles";
 import ChannelType, { CommandInteraction, Guild, GuildMember, GuildMemberResolvable, GuildResolvable, Interaction, Message, RoleResolvable, UserResolvable } from "discord.js";
 import moment from "moment";
 import { Command, StringReplacements } from "../../typings";
-import { promisify } from "util";
-import {GuildModel} from "../models/guilds";
-import glob from "glob";
+import { GuildModel } from "../models/guilds";
 import { Bot } from "../bot";
-import {UserModel} from "../models/users";
+import { UserModel } from "../models/users";
 import * as cryptojs from "crypto-js";
 import { DocumentType } from "@typegoose/typegoose";
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,7 +9,7 @@ import * as errors from "./errors";
 import * as general from "./general";
 import * as embeds from "./embeds";
 import * as voice from "./voice";
-export {errors, general, embeds, voice};
+export { errors, general, embeds, voice };
 // module.exports = { //TODO dynamically read new Util classes
 //     errors: require('./errors'),
 //     // functions: require('./functions'),

--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -1,7 +1,7 @@
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
 import { ChannelType, Guild, GuildMember, GuildPremiumTier, OverwriteData } from "discord.js";
 import { Bot } from "../bot";
-import {GuildModel} from "../models/guilds";
+import { GuildModel } from "../models/guilds";
 import { VoiceChannel } from "../models/voice_channels";
 import { VoiceChannelSpawner } from "../models/voice_channel_spawner";
 import { mongoose } from "@typegoose/typegoose";


### PR DESCRIPTION
I only manually changed the eslintrc.json and package.json to include rules for spaces around commas and curly braces and remove unused imports. I used the formatting which was prevalent in this codebase but not applied everywhere. 

All changes to other files were by the eslint autofix. It adjusted the spaces as described above and removed unused imports. 