### PR TITLE
Add permissions to job

### DIFF
--- a/.github/workflows/docker-img.yml
+++ b/.github/workflows/docker-img.yml
@@ -20,6 +20,9 @@ jobs:
   ghr_push:
     name: Build and publish container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: checkout


### PR DESCRIPTION
This hopefully fixes the problems with the workflow runs where the upload failed because of a 403 Forbidden error when pushing the image to the registry.

But I don't know why the workflow ran successfully the previous tries.