### PR TITLE
Add data volume to docker compose

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,4 +1,8 @@
 version: '3.8'
+
+volumes:
+  sprechi-mongodb-data:
+
 services:
   db:
     image: mongo
@@ -8,5 +12,7 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
       - MONGO_INITDB_DATABASE=$MONGODB_DBNAME
     restart: unless-stopped
+    volumes:
+      - sprechi-mongodb-data:/data/db
     ports:
       - 27017:27017


### PR DESCRIPTION
This adds a data volume to the docker compose. This is helpful when it is necessary to delete the db image or it is accidentally deleted since the actual mongo db data is saved in the volume which does not get deleted with the image.

I think this would also be a good idea for the other docker compose files.