### PR TITLE
#53: improve join queue + added commands to set messages

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -6,12 +6,12 @@ import { BotEvent, ButtonInteraction, Command } from "../typings";
 import glob from "glob-promise";
 import * as fs from "fs";
 import * as utils from "./utils/utils";
-import { GuildModel } from "./models/guilds";
 import parser from "yargs-parser";
 import mongoose from "mongoose";
 import path from "path/posix";
 import { QueueSpan } from "./models/queue_span";
 import { WeekTimestamp } from "./models/week_timestamp";
+import {GuildModel} from "./models/models";
 export class Bot extends Client {
     public logger: ConsolaInstance = consola;
     public commands: Collection<string, Command> = new Collection();

--- a/src/commands/admin/member/lookup-by.ts
+++ b/src/commands/admin/member/lookup-by.ts
@@ -1,9 +1,10 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { UserModel, User } from "../../../models/users";
+import { User } from "../../../models/users";
 import { FilterQuery } from "mongoose";
 import { DocumentType, mongoose } from "@typegoose/typegoose";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
+import {UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "lookup-by",

--- a/src/commands/admin/member/lookup.ts
+++ b/src/commands/admin/member/lookup.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { UserModel } from "../../../models/users";
+import {UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "lookup",

--- a/src/commands/admin/member/unverify.ts
+++ b/src/commands/admin/member/unverify.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { UserModel } from "../../../models/users";
+import {UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "unverify",

--- a/src/commands/admin/queue/fixup.ts
+++ b/src/commands/admin/queue/fixup.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, Message, Role } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
+import {GuildModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "fixup",

--- a/src/commands/admin/queue/info.ts
+++ b/src/commands/admin/queue/info.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "info",

--- a/src/commands/admin/queue/kick.ts
+++ b/src/commands/admin/queue/kick.ts
@@ -1,8 +1,8 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
 import QueueInfoService from "../../../service/queue-info/QueueInfoService";
 import { QueueEventType } from "../../../models/events";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "kick",

--- a/src/commands/admin/queue/list.ts
+++ b/src/commands/admin/queue/list.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, GuildMember, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "list",

--- a/src/commands/admin/queue/lock.ts
+++ b/src/commands/admin/queue/lock.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message, VoiceChannel } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "lock",

--- a/src/commands/admin/queue/unlock.ts
+++ b/src/commands/admin/queue/unlock.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message, VoiceChannel } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "unlock",

--- a/src/commands/admin/queue/userrank.ts
+++ b/src/commands/admin/queue/userrank.ts
@@ -1,8 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
-import { RoomModel } from "../../../models/rooms";
+import {GuildModel, RoomModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "userrank",

--- a/src/commands/admin/queue/userstats.ts
+++ b/src/commands/admin/queue/userstats.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { RoomModel } from "../../../models/rooms";
+import {GuildModel, RoomModel} from "../../../models/models";
 
 const command: Command = {
     name: "userstats",

--- a/src/commands/admin/session/list.ts
+++ b/src/commands/admin/session/list.ts
@@ -1,7 +1,6 @@
 import { EmbedField, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { SessionModel } from "../../../models/sessions";
+import {GuildModel, SessionModel} from "../../../models/models";
 
 const command: Command = {
     name: "list",

--- a/src/commands/admin/session/terminate.ts
+++ b/src/commands/admin/session/terminate.ts
@@ -1,8 +1,7 @@
 import { ApplicationCommandOptionType, EmbedField, Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { SessionModel } from "../../../models/sessions";
+import {GuildModel, SessionModel} from "../../../models/models";
 
 const command: Command = {
     name: "terminate",

--- a/src/commands/admin/session/terminateall.ts
+++ b/src/commands/admin/session/terminateall.ts
@@ -1,8 +1,9 @@
 import { EmbedField, Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { SessionModel } from "../../../models/sessions";
+import {GuildModel, SessionModel} from "../../../models/models";
+
+
 
 const command: Command = {
     name: "terminateall",

--- a/src/commands/admin/setinternalrole.ts
+++ b/src/commands/admin/setinternalrole.ts
@@ -1,9 +1,9 @@
 import { Message, ApplicationCommandOptionType } from "discord.js";
 import { Command } from "../../../typings";
 import "moment-duration-format";
-import { GuildModel } from "../../models/guilds";
 import { InternalGuildRoles, InternalRoles, RoleScopes } from "../../models/bot_roles";
 import { mongoose } from "@typegoose/typegoose";
+import {GuildModel} from "../../models/models";
 
 
 

--- a/src/commands/admin/setjoinmessage.ts
+++ b/src/commands/admin/setjoinmessage.ts
@@ -1,0 +1,59 @@
+import { Message, ApplicationCommandOptionType } from "discord.js";
+import { Command } from "../../../typings";
+import "moment-duration-format";
+import {UserError} from "../../service/error/UserError";
+import {QueueService} from "../../service/queue/QueueService";
+
+
+
+/**
+ * The Command Definition
+ */
+const command: Command = {
+    name: "setjoinmessage",
+    guildOnly: false,
+    description: "Sets the join message for a specific queue",
+    options: [
+        {
+            name: "message",
+            description: "new join message",
+            type: ApplicationCommandOptionType.String,
+            required: true,
+        },
+        {
+            name: "queue",
+            description: "name of the queue",
+            type: ApplicationCommandOptionType.String,
+            required: true,
+        },
+    ],
+    async execute(client, interaction, args) {
+        if (!interaction || !interaction.guild) {
+            return;
+        }
+        if (interaction instanceof Message) {
+            client.utils.embeds.SimpleEmbed(interaction, "Slash Only Command", "This Command is Slash only but you Called it with The Prefix. use the slash Command instead.");
+            return;
+        }
+
+        const g = interaction!.guild!;
+        const queue = interaction.options.getString("queue", true);
+        const joinMessage = interaction.options.getString("message", true)
+
+        try {
+            await QueueService.setJoinMessage(g, queue, joinMessage)
+            return await client.utils.embeds.SimpleEmbed(interaction, { title: "Success", text: `new join message set for queue: ${queue}`, empheral: true });
+        } catch (error) {
+            if (error instanceof UserError) {
+                return await client.utils.embeds.SimpleEmbed(interaction, { title: "Command Execution failed", text: error.message, empheral: true });
+            } else {
+                return await client.utils.embeds.SimpleEmbed(interaction, { title: "Command Execution failed", text: "Could not perform command: Internal Server Error!", empheral: true });
+            }
+        }
+    },
+};
+
+/**
+ * Exporting the Command using CommonJS
+ */
+module.exports = command;

--- a/src/commands/admin/setleavemessage.ts
+++ b/src/commands/admin/setleavemessage.ts
@@ -1,0 +1,59 @@
+import { Message, ApplicationCommandOptionType } from "discord.js";
+import { Command } from "../../../typings";
+import "moment-duration-format";
+import {UserError} from "../../service/error/UserError";
+import {QueueService} from "../../service/queue/QueueService";
+
+
+
+/**
+ * The Command Definition
+ */
+const command: Command = {
+    name: "setleavemessage",
+    guildOnly: false,
+    description: "Sets the leave message for a specific queue",
+    options: [
+        {
+            name: "message",
+            description: "new leave message",
+            type: ApplicationCommandOptionType.String,
+            required: true,
+        },
+        {
+            name: "queue",
+            description: "name of the queue",
+            type: ApplicationCommandOptionType.String,
+            required: true,
+        },
+    ],
+    async execute(client, interaction, args) {
+        if (!interaction || !interaction.guild) {
+            return;
+        }
+        if (interaction instanceof Message) {
+            client.utils.embeds.SimpleEmbed(interaction, "Slash Only Command", "This Command is Slash only but you Called it with The Prefix. use the slash Command instead.");
+            return;
+        }
+
+        const g = interaction!.guild!;
+        const queue = interaction.options.getString("queue", true);
+        const leaveMessage = interaction.options.getString("message", true)
+
+        try {
+            await QueueService.setLeaveMessage(g, queue, leaveMessage)
+            return await client.utils.embeds.SimpleEmbed(interaction, { title: "Success", text: `new leave message set for queue: ${queue}`, empheral: true });
+        } catch (error) {
+            if (error instanceof UserError) {
+                return await client.utils.embeds.SimpleEmbed(interaction, { title: "Command Execution failed", text: error.message, empheral: true });
+            } else {
+                return await client.utils.embeds.SimpleEmbed(interaction, { title: "Command Execution failed", text: "Could not perform command: Internal Server Error!", empheral: true });
+            }
+        }
+    },
+};
+
+/**
+ * Exporting the Command using CommonJS
+ */
+module.exports = command;

--- a/src/commands/admin/updatebotroles.ts
+++ b/src/commands/admin/updatebotroles.ts
@@ -2,9 +2,9 @@ import { InternalGuildRoles } from "../../models/bot_roles";
 import { Message, ApplicationCommandOptionType } from "discord.js";
 import { Command } from "../../../typings";
 import "moment-duration-format";
-import { GuildModel } from "../../models/guilds";
 import { RoleScopes } from "../../models/bot_roles";
 import { mongoose } from "@typegoose/typegoose";
+import {GuildModel} from "../../models/models";
 
 
 

--- a/src/commands/admin/updateuserroles.ts
+++ b/src/commands/admin/updateuserroles.ts
@@ -1,11 +1,10 @@
 import { Message, Role } from "discord.js";
 import { Command } from "../../../typings";
 import "moment-duration-format";
-import { UserModel } from "../../models/users";
-import { GuildModel } from "../../models/guilds";
 import { DBRole } from "../../models/bot_roles";
 import { Types } from "mongoose";
 import { ArraySubDocumentType } from "@typegoose/typegoose";
+import {GuildModel, UserModel} from "../../models/models";
 
 
 

--- a/src/commands/coach/info.ts
+++ b/src/commands/coach/info.ts
@@ -1,8 +1,7 @@
 import { Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
-import { UserModel } from "../../models/users";
+import {GuildModel, UserModel} from "../../models/models";
 
 const command: Command = {
     name: "info",

--- a/src/commands/coach/queue/info.ts
+++ b/src/commands/coach/queue/info.ts
@@ -1,7 +1,6 @@
 import { Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
+import {GuildModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "info",

--- a/src/commands/coach/queue/list.ts
+++ b/src/commands/coach/queue/list.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, EmbedField, GuildMember, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
+import {GuildModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "list",

--- a/src/commands/coach/queue/next.ts
+++ b/src/commands/coach/queue/next.ts
@@ -2,13 +2,11 @@ import { VoiceChannelEvent as EVT, VoiceChannelEventType } from "./../../../mode
 import { PermissionOverwriteData } from "../../../models/permission_overwrite_data";
 import ChannelType, { ApplicationCommandOptionType, Message, TextChannel } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
-import { RoomModel } from "../../../models/rooms";
 import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
 import { mongoose } from "@typegoose/typegoose";
 import QueueInfoService from "../../../service/queue-info/QueueInfoService";
 import { QueueEventType } from "../../../models/events";
+import {GuildModel, RoomModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "next",

--- a/src/commands/coach/queue/pick.ts
+++ b/src/commands/coach/queue/pick.ts
@@ -3,12 +3,10 @@ import { VoiceChannelEvent as EVT, QueueEventType, VoiceChannelEventType } from 
 import { PermissionOverwriteData } from "../../../models/permission_overwrite_data";
 import ChannelType, { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
-import { RoomModel } from "../../../models/rooms";
 import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
 import { mongoose } from "@typegoose/typegoose";
 import QueueInfoService from "../../../service/queue-info/QueueInfoService";
+import {GuildModel, RoomModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "pick",

--- a/src/commands/coach/session/info.ts
+++ b/src/commands/coach/session/info.ts
@@ -1,8 +1,7 @@
 import { Message } from "discord.js";
 import moment from "moment";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
+import {GuildModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "info",

--- a/src/commands/coach/session/quit.ts
+++ b/src/commands/coach/session/quit.ts
@@ -1,12 +1,11 @@
 import { Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
 import moment from "moment";
 import { removeRoleFromUser } from "../../../utils/general";
 import { InternalRoles } from "../../../models/bot_roles";
 import QueueInfoService from "../../../service/queue-info/QueueInfoService";
 import { QueueEventType } from "../../../models/events";
+import {GuildModel, UserModel} from "../../../models/models";
 
 const command: Command = {
     name: "quit",

--- a/src/commands/coach/session/start.ts
+++ b/src/commands/coach/session/start.ts
@@ -1,12 +1,11 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
-import { UserModel } from "../../../models/users";
-import { SessionModel, sessionRole } from "../../../models/sessions";
 import { assignRoleToUser } from "../../../utils/general";
 import { InternalRoles } from "../../../models/bot_roles";
 import QueueInfoService from "../../../service/queue-info/QueueInfoService";
 import { QueueEventType } from "../../../models/events";
+import {GuildModel, SessionModel, UserModel} from "../../../models/models";
+import {sessionRole} from "../../../models/sessions";
 
 const command: Command = {
     name: "start",

--- a/src/commands/config/commands/permission.ts
+++ b/src/commands/config/commands/permission.ts
@@ -1,7 +1,7 @@
 import { SlashCommandPermission } from "./../../../models/slash_command_permission";
 import { ApplicationCommandOptionType, Message, Role } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "permission",

--- a/src/commands/config/commands/rename.ts
+++ b/src/commands/config/commands/rename.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "rename",

--- a/src/commands/config/commands/visibility.ts
+++ b/src/commands/config/commands/visibility.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "visibility",

--- a/src/commands/config/queue/add_unlock_time.ts
+++ b/src/commands/config/queue/add_unlock_time.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
 import { QueueSpan } from "../../../models/queue_span";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "add_unlock_time",

--- a/src/commands/config/queue/autolock.ts
+++ b/src/commands/config/queue/autolock.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "autolock",

--- a/src/commands/config/queue/create.ts
+++ b/src/commands/config/queue/create.ts
@@ -1,9 +1,9 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
 import { Queue } from "../../../models/queues";
 import { mongoose } from "@typegoose/typegoose";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "create",

--- a/src/commands/config/queue/get_schedules.ts
+++ b/src/commands/config/queue/get_schedules.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 import { QueueSpan } from "../../../models/queue_span";
 import { WeekTimestamp } from "../../../models/week_timestamp";
 

--- a/src/commands/config/queue/remove_unlock_time.ts
+++ b/src/commands/config/queue/remove_unlock_time.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 import { QueueSpan } from "../../../models/queue_span";
 import { WeekTimestamp } from "../../../models/week_timestamp";
 

--- a/src/commands/config/queue/set_category.ts
+++ b/src/commands/config/queue/set_category.ts
@@ -1,8 +1,8 @@
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
-import { VoiceChannelSpawner } from "./../../../models/voice_channel_spawner";
+import { VoiceChannelSpawner } from "../../../models/voice_channel_spawner";
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 import { mongoose } from "@typegoose/typegoose";
 
 const command: Command = {

--- a/src/commands/config/queue/set_closing_shift.ts
+++ b/src/commands/config/queue/set_closing_shift.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "set_closing_shift",

--- a/src/commands/config/queue/set_opening_shift.ts
+++ b/src/commands/config/queue/set_opening_shift.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "set_opening_shift",

--- a/src/commands/config/queue/set_text_channel.ts
+++ b/src/commands/config/queue/set_text_channel.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel} from "../../../models/models";
 
 const command: Command = {
     name: "set_text_channel",

--- a/src/commands/config/queue/set_waiting_room.ts
+++ b/src/commands/config/queue/set_waiting_room.ts
@@ -1,7 +1,6 @@
-import { VoiceChannelModel } from "../../../models/voice_channels";
 import { ApplicationCommandOptionType, GuildChannel, Message } from "discord.js";
 import { Command } from "../../../../typings";
-import { GuildModel } from "../../../models/guilds";
+import {GuildModel, VoiceChannelModel} from "../../../models/models";
 import { VoiceChannel } from "../../../models/voice_channels";
 import { mongoose } from "@typegoose/typegoose";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";

--- a/src/commands/config/setjointocreate.ts
+++ b/src/commands/config/setjointocreate.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, CategoryChannel, GuildChannel, Message, VoiceChannel as dvc } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 import { VoiceChannel } from "../../models/voice_channels";
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
 import { mongoose } from "@typegoose/typegoose";

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType, EmojiIdentifierResolvable, Message, EmbedBuilder } from "discord.js";
 import yargsParser from "yargs-parser";
 import { Command } from "../../typings";
-import { GuildModel } from "../models/guilds";
+import { GuildModel } from "../models/models";
 
 
 const command: Command = {

--- a/src/commands/queue/info.ts
+++ b/src/commands/queue/info.ts
@@ -1,6 +1,6 @@
 import { Message, EmbedField } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "info",

--- a/src/commands/queue/join.ts
+++ b/src/commands/queue/join.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandOptionType, Message } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
-import { UserModel } from "../../models/users";
+import { GuildModel, UserModel } from "../../models/models";
 import { manageJoinQueue } from "../../utils/general";
 
 
@@ -81,7 +80,7 @@ const command: Command = {
             console.log(error);
         }
 
-        await client.utils.embeds.SimpleEmbed(interaction, { title: "Coaching System", text: queueData.getJoinMessage(user.id), empheral: true });
+        await client.utils.embeds.SimpleEmbed(interaction, { title: "Coaching System", text: await queueData.getJoinMessage(user.id), empheral: true });
 
         // await client.utils.embeds.SimpleEmbed(interaction, "TODO", `Command \`${path.relative(process.cwd(), __filename)}\` is not Implemented Yet.`);
 

--- a/src/commands/queue/leave.ts
+++ b/src/commands/queue/leave.ts
@@ -1,6 +1,6 @@
 import { Message } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 import QueueInfoService from "../../service/queue-info/QueueInfoService";
 import { QueueEventType } from "../../models/events";
 
@@ -31,7 +31,7 @@ const command: Command = {
             return await client.utils.embeds.SimpleEmbed(interaction, { title: "Coaching System", text: "You are currently not in a queue.", empheral: true });
         }
 
-        const leave_msg = queueData.getLeaveMessage(user.id);
+        const leave_msg = await queueData.getLeaveMessage(user.id);
         await queueData.leave(user.id);
 
 

--- a/src/commands/queue/list.ts
+++ b/src/commands/queue/list.ts
@@ -1,6 +1,6 @@
 import { Message } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "list",

--- a/src/commands/voice/close.ts
+++ b/src/commands/voice/close.ts
@@ -1,6 +1,6 @@
 import { Message } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "close",

--- a/src/commands/voice/kick.ts
+++ b/src/commands/voice/kick.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, GuildMember, Message } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "kick",

--- a/src/commands/voice/lock.ts
+++ b/src/commands/voice/lock.ts
@@ -1,5 +1,5 @@
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "lock",

--- a/src/commands/voice/permit.ts
+++ b/src/commands/voice/permit.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, GuildMember, Message } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "permit",

--- a/src/commands/voice/togglelock.ts
+++ b/src/commands/voice/togglelock.ts
@@ -1,6 +1,6 @@
 import { OverwriteData } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "togglelock",

--- a/src/commands/voice/togglevisibility.ts
+++ b/src/commands/voice/togglevisibility.ts
@@ -1,5 +1,5 @@
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "togglevisibility",

--- a/src/commands/voice/transfer.ts
+++ b/src/commands/voice/transfer.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionType, GuildMember, Message } from "discord.js";
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "transfer",

--- a/src/commands/voice/unlock.ts
+++ b/src/commands/voice/unlock.ts
@@ -1,5 +1,5 @@
 import { Command } from "../../../typings";
-import { GuildModel } from "../../models/guilds";
+import { GuildModel } from "../../models/models";
 
 const command: Command = {
     name: "unlock",

--- a/src/componentInteractions/buttons/queue/leave.ts
+++ b/src/componentInteractions/buttons/queue/leave.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder } from "discord.js";
 import { ButtonInteraction } from "../../../../typings";
-import { Guild, GuildModel } from "../../../models/guilds";
+import { Guild } from "../../../models/guilds";
+import { GuildModel } from "../../../models/models";
 import { Queue } from "../../../models/queues";
 import { ArraySubDocumentType, DocumentType } from "@typegoose/typegoose";
 import QueueInfoService from "../../../service/queue-info/QueueInfoService";
@@ -37,7 +38,7 @@ const command: ButtonInteraction = {
 
 
         // Leave the Queue
-        const leave_msg = queue.getLeaveMessage(interaction.user.id);
+        const leave_msg = await queue.getLeaveMessage(interaction.user.id);
         await queue.leave(interaction.user.id);
         let color = 0x7289da;
         try {

--- a/src/componentInteractions/buttons/queue/refresh.ts
+++ b/src/componentInteractions/buttons/queue/refresh.ts
@@ -1,7 +1,8 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from "discord.js";
 import moment from "moment";
 import { ButtonInteraction } from "../../../../typings";
-import { GuildModel, Guild } from "../../../models/guilds";
+import { Guild } from "../../../models/guilds";
+import { GuildModel } from "../../../models/models";
 import { Queue } from "../../../models/queues";
 import { DocumentType } from "@typegoose/typegoose";
 

--- a/src/componentInteractions/buttons/queue/stay.ts
+++ b/src/componentInteractions/buttons/queue/stay.ts
@@ -1,6 +1,7 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Collection, EmbedBuilder } from "discord.js";
 import { ButtonInteraction } from "../../../../typings";
-import { GuildModel, Guild } from "../../../models/guilds";
+import { Guild } from "../../../models/guilds";
+import { GuildModel } from "../../../models/models";
 import { Queue } from "../../../models/queues";
 import { DocumentType } from "@typegoose/typegoose";
 

--- a/src/events/GuildCreateEvent.ts
+++ b/src/events/GuildCreateEvent.ts
@@ -1,5 +1,5 @@
 import { ExecuteEvent } from "../../typings";
-import { GuildModel } from "../models/guilds";
+import { GuildModel } from "../models/models";
 
 export const name = "guildCreate";
 

--- a/src/events/InteractionCreateEvent.ts
+++ b/src/events/InteractionCreateEvent.ts
@@ -1,7 +1,7 @@
 import { ExecuteEvent } from "../../typings";
 import { ChatInputCommandInteraction, Collection } from "discord.js";
 export const name = "interactionCreate";
-import { GuildModel } from "../models/guilds";
+import { GuildModel } from "../models/models";
 
 export const execute: ExecuteEvent<"interactionCreate"> = async (client, interaction) => {
 

--- a/src/events/ReadyEvent.ts
+++ b/src/events/ReadyEvent.ts
@@ -1,6 +1,6 @@
 import { ExecuteEvent } from "../../typings";
 import { ActivityType, ApplicationCommandData } from "discord.js";
-import { GuildModel } from "../models/guilds";
+import { GuildModel } from "../models/models";
 
 export const execute: ExecuteEvent<"ready"> = async (client) => {
     // -- Setup Databases -- //

--- a/src/events/guildMemberAddEvent.ts
+++ b/src/events/guildMemberAddEvent.ts
@@ -1,6 +1,5 @@
 import { ExecuteEvent, StringReplacements } from "../../typings";
-import { GuildModel } from "../models/guilds";
-import { UserModel } from "../models/users";
+import { GuildModel, UserModel } from "../models/models";
 
 export const name = "guildMemberAdd";
 

--- a/src/events/guildMemberRemoveEvent.ts
+++ b/src/events/guildMemberRemoveEvent.ts
@@ -1,5 +1,5 @@
 import { ExecuteEvent } from "../../typings";
-import { UserModel } from "../models/users";
+import { UserModel } from "../models/models";
 
 export const name = "guildMemberRemove";
 

--- a/src/models/bot_roles.ts
+++ b/src/models/bot_roles.ts
@@ -1,4 +1,4 @@
-import { getModelForClass, prop } from "@typegoose/typegoose";
+import { prop } from "@typegoose/typegoose";
 
 export enum InternalRoles {
     SERVER_OWNER = "server_owner",
@@ -63,8 +63,3 @@ export interface BotRole extends DBRole {
     scope: RoleScopes.GLOBAL,
 }
 
-export const DBRoleModel = getModelForClass(DBRole, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/guild_settings.ts
+++ b/src/models/guild_settings.ts
@@ -1,6 +1,6 @@
 import { DBRole } from "./bot_roles";
 import { SlashCommandSettings } from "./slash_command_settings";
-import { ArraySubDocumentType, DocumentType, getModelForClass, mongoose, prop } from "@typegoose/typegoose";
+import { ArraySubDocumentType, DocumentType, mongoose, prop } from "@typegoose/typegoose";
 
 /**
  * Command Listen Modes
@@ -80,8 +80,3 @@ export class GuildSettings {
     }
 }
 
-export const GuildSettingsModel = getModelForClass(GuildSettings, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/guilds.ts
+++ b/src/models/guilds.ts
@@ -4,9 +4,10 @@ import { TextChannel } from "./text_channels";
 import { VoiceChannel } from "./voice_channels";
 import * as djs from "discord.js";
 import { ApplicationCommandData, ApplicationCommandOptionChoiceData } from "discord.js";
-import { prop, getModelForClass, DocumentType, ReturnModelType, SubDocumentType, ArraySubDocumentType, mongoose } from "@typegoose/typegoose";
+import { prop, DocumentType, ReturnModelType, SubDocumentType, ArraySubDocumentType, mongoose } from "@typegoose/typegoose";
 import { Command, SubcommandHandler } from "../../typings";
 import { GuildSettings } from "./guild_settings";
+import {GuildModel} from "./models";
 
 /**
  * A Guild from the Database
@@ -195,8 +196,3 @@ export class Guild {
     }
 }
 
-export const GuildModel = getModelForClass(Guild, {
-    schemaOptions: {
-        autoCreate: true,
-    },
-});

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1,0 +1,120 @@
+import {getModelForClass} from "@typegoose/typegoose";
+import {User} from "./users";
+import {Session} from "./sessions";
+import {DBRole} from "./bot_roles";
+import {GuildSettings} from "./guild_settings";
+import {Guild} from "./guilds";
+import {PermissionOverwriteData} from "./permission_overwrite_data";
+import {QueueEntry} from "./queue_entry";
+import {QueueSpan} from "./queue_span";
+import {Queue} from "./queues";
+import {Room} from "./rooms";
+import {SlashCommandSettings} from "./slash_command_settings";
+import {TextChannel} from "./text_channels";
+import {VoiceChannelSpawner} from "./voice_channel_spawner";
+import {VoiceChannel} from "./voice_channels";
+import {WeekTimestamp} from "./week_timestamp";
+
+export const UserModel = getModelForClass(User, {
+    schemaOptions: {
+        autoCreate: true,
+    },
+});
+
+
+export const SessionModel = getModelForClass(Session, {
+    schemaOptions: {
+        autoCreate: true,
+    },
+});
+
+
+export const DBRoleModel = getModelForClass(DBRole, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const GuildSettingsModel = getModelForClass(GuildSettings, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const GuildModel = getModelForClass(Guild, {
+    schemaOptions: {
+        autoCreate: true,
+    },
+});
+
+
+export const PermissionOverwriteDataModel = getModelForClass(PermissionOverwriteData, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const QueueEntryModel = getModelForClass(QueueEntry, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const QueueSpanModel = getModelForClass(QueueSpan, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const QueueModel = getModelForClass(Queue, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const RoomModel = getModelForClass(Room, {
+    schemaOptions: {
+        autoCreate: true,
+    },
+});
+
+
+export const SlashCommandSettingsModel = getModelForClass(SlashCommandSettings, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const TextChannelModel = getModelForClass(TextChannel, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const VoiceChannelSpawnerModel = getModelForClass(VoiceChannelSpawner, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const VoiceChannelModel = getModelForClass(VoiceChannel, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});
+
+
+export const WeekTimestampModel = getModelForClass(WeekTimestamp, {
+    schemaOptions: {
+        autoCreate: false,
+    },
+});

--- a/src/models/permission_overwrite_data.ts
+++ b/src/models/permission_overwrite_data.ts
@@ -1,5 +1,5 @@
 import { OverwriteData, PermissionResolvable, Snowflake } from "discord.js";
-import { getModelForClass, prop } from "@typegoose/typegoose";
+import { prop } from "@typegoose/typegoose";
 
 export class PermissionOverwriteData implements OverwriteData {
     @prop({ required: true, type: String })
@@ -10,8 +10,3 @@ export class PermissionOverwriteData implements OverwriteData {
         deny?: PermissionResolvable[];
 }
 
-export const PermissionOverwriteDataModel = getModelForClass(PermissionOverwriteData, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/queue_entry.ts
+++ b/src/models/queue_entry.ts
@@ -1,4 +1,4 @@
-import { getModelForClass, prop } from "@typegoose/typegoose";
+import { prop } from "@typegoose/typegoose";
 
 /**
  * A Queue Entry
@@ -26,8 +26,3 @@ export class QueueEntry {
         intent?: string;
 }
 
-export const QueueEntryModel = getModelForClass(QueueEntry, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/queue_span.ts
+++ b/src/models/queue_span.ts
@@ -1,5 +1,5 @@
 import { WeekTimestamp, Weekday } from "./week_timestamp";
-import { getModelForClass, prop } from "@typegoose/typegoose";
+import { prop } from "@typegoose/typegoose";
 
 /**
  * A Queue Span - A Weekly Timespan with a start- and End Date that can be used to automate Events every week
@@ -118,6 +118,14 @@ export class QueueSpan {
         return this.end.getTime() + this.closeShift;
     }
 
+    public getActualEndTimeFormatted(): string {
+        return new Date(this.actualEndTime()).toLocaleTimeString('de-DE', {
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'Europe/Berlin'
+        }).slice(0, 5);
+    }
+
     /**
      * Checks whether the span is active at a given Date (or now if no date was given)
      * 
@@ -187,8 +195,3 @@ export class QueueSpan {
     }
 }
 
-export const QueueSpanModel = getModelForClass(QueueSpan, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/queues.ts
+++ b/src/models/queues.ts
@@ -9,6 +9,7 @@ import { Guild } from "./guilds";
 import { VoiceChannelSpawner } from "./voice_channel_spawner";
 import { QueueEventType } from "./events";
 import djs from "discord.js";
+import {SessionModel} from "./models";
 
 /**
  * A Queue from the Database
@@ -177,31 +178,31 @@ export class Queue {
      * Interpolates the Queue String
      * @param string The String to Interpolate
      */
-    public interpolateQueueString(this: DocumentType<Queue>, string: string): string | null;
+    public interpolateQueueString(this: DocumentType<Queue>, string: string): Promise<string | null>;
     /**
      * Interpolates the Queue String
      * @param string The String to Interpolate
      * @param discord_id The Discord ID of the Entry
      */
-    public interpolateQueueString(this: DocumentType<Queue>, string: string, discord_id: string): string | null;
+    public interpolateQueueString(this: DocumentType<Queue>, string: string, discord_id: string): Promise<string | null>;
     /**
      * Interpolates the Queue String
      * @param string The String to Interpolate
      * @param entry The Queue Entry
      */
-    public interpolateQueueString(this: DocumentType<Queue>, string: string, entry: QueueEntry): string | null;
+    public interpolateQueueString(this: DocumentType<Queue>, string: string, entry: QueueEntry): Promise<string | null>;
     /**
      * Interpolates the Queue String
      * @param string The String to Interpolate
      * @param entry_resolvable The Entry Resolvable
      */
-    public interpolateQueueString(this: DocumentType<Queue>, string: string, entry_resolvable?: string | QueueEntry | undefined): string | null;
+    public interpolateQueueString(this: DocumentType<Queue>, string: string, entry_resolvable?: string | QueueEntry | undefined): Promise<string | null>;
     /**
      * Interpolates the Queue String
      * @param string The String to Interpolate
      * @param entry_resolvable The Entry Resolvable
      */
-    public interpolateQueueString(this: DocumentType<Queue>, string: string, entry_resolvable?: string | QueueEntry | undefined): string | null {
+    public async interpolateQueueString(this: DocumentType<Queue>, string: string, entry_resolvable?: string | QueueEntry | undefined): Promise<string | null> {
         try {
             const replacements: StringReplacements = {
                 "limit": this.limit,
@@ -210,6 +211,8 @@ export class Queue {
                 "eta": "null",
                 "timeout": (this.disconnect_timeout ?? 0) / 1000,
                 "total": this.entries.length,
+                "active_coaches": (await SessionModel.find({queue: this, active: true})).length,
+                "closing_time": this.opening_times.find(queueSpan => queueSpan.isActive())?.getActualEndTimeFormatted()
             };
 
             if (entry_resolvable) {
@@ -242,25 +245,25 @@ export class Queue {
     /**
      * Gets the leave Message of the Queue
      */
-    public getLeaveMessage(this: DocumentType<Queue>): string;
+    public getLeaveMessage(this: DocumentType<Queue>): Promise<string>;
     /**
      * Gets the leave Message of the Queue
      * @param discord_id The Discord ID of the Leaver
      */
-    public getLeaveMessage(this: DocumentType<Queue>, discord_id: string): string;
+    public getLeaveMessage(this: DocumentType<Queue>, discord_id: string): Promise<string>;
     /**
      * Gets the leave Message of the Queue
      * @param entry The Entry that wants to leave the queue
      */
-    public getLeaveMessage(this: DocumentType<Queue>, entry: QueueEntry): string;
+    public getLeaveMessage(this: DocumentType<Queue>, entry: QueueEntry): Promise<string>;
     /**
      * Gets the leave Message of the Queue
      * @param entry_resolvable The Entry Resolvable
      */
-    public getLeaveMessage(this: DocumentType<Queue>, entry_resolvable?: string | QueueEntry | undefined): string {
+    public async getLeaveMessage(this: DocumentType<Queue>, entry_resolvable?: string | QueueEntry | undefined): Promise<string> {
         const default_leave_message = "You left the Queue.";
         if (this.leave_message) {
-            const leave_msg = this.interpolateQueueString(this.leave_message!, entry_resolvable);
+            const leave_msg = await this.interpolateQueueString(this.leave_message!, entry_resolvable);
             return leave_msg ?? default_leave_message;
         }
         else {
@@ -270,25 +273,25 @@ export class Queue {
     /**
      * Gets the leave Room Message of the Queue
      */
-    public getLeaveRoomMessage(this: DocumentType<Queue>): string;
+    public async getLeaveRoomMessage(this: DocumentType<Queue>): Promise<string>;
     /**
      * Gets the leave Room Message of the Queue
      * @param discord_id The Discord ID of the Leaver
      */
-    public getLeaveRoomMessage(this: DocumentType<Queue>, discord_id: string): string;
+    public async getLeaveRoomMessage(this: DocumentType<Queue>, discord_id: string): Promise<string>;
     /**
      * Gets the leave Room Message of the Queue
      * @param entry The Entry that wants to leave the queue
      */
-    public getLeaveRoomMessage(this: DocumentType<Queue>, entry: QueueEntry): string;
+    public async getLeaveRoomMessage(this: DocumentType<Queue>, entry: QueueEntry): Promise<string>;
     /**
      * Gets the leave Room Message of the Queue
      * @param entry_resolvable The Entry Resolvable
      */
-    public getLeaveRoomMessage(this: DocumentType<Queue>, entry_resolvable?: string | QueueEntry | undefined): string {
+    public async getLeaveRoomMessage(this: DocumentType<Queue>, entry_resolvable?: string | QueueEntry | undefined): Promise<string> {
         const default_leave_message = `You left the Room. Please confirm your stay or you will be removed from the queue after the Timeout of ${(this.disconnect_timeout ?? 0) / 1000}s.`;
         if (this.leave_room_message) {
-            const leave_msg = this.interpolateQueueString(this.leave_room_message, entry_resolvable);
+            const leave_msg = await this.interpolateQueueString(this.leave_room_message, entry_resolvable);
             return leave_msg ?? default_leave_message;
         }
         else {
@@ -298,25 +301,25 @@ export class Queue {
     /**
      * Gets the join Message of the Queue
      */
-    public getJoinMessage(this: DocumentType<Queue>): string;
+    public async getJoinMessage(this: DocumentType<Queue>): Promise<string>;
     /**
      * Gets the join Message of the Queue
      * @param discord_id The Discord ID of the Joiner
      */
-    public getJoinMessage(this: DocumentType<Queue>, discord_id: string): string;
+    public async getJoinMessage(this: DocumentType<Queue>, discord_id: string): Promise<string>;
     /**
      * Gets the join Message of the Queue
      * @param entry The Entry that wants to join the queue
      */
-    public getJoinMessage(this: DocumentType<Queue>, entry: QueueEntry): string;
+    public async getJoinMessage(this: DocumentType<Queue>, entry: QueueEntry): Promise<string>;
     /**
      * Gets the leave Message of the Queue
      * @param entry_resolvable The Entry Resolvable
      */
-    public getJoinMessage(this: DocumentType<Queue>, entry_resolvable?: string | QueueEntry | undefined): string {
+    public async getJoinMessage(this: DocumentType<Queue>, entry_resolvable?: string | QueueEntry | undefined): Promise<string> {
         const default_join_message = "You left the Queue.";
         if (this.join_message) {
-            const join_msg = this.interpolateQueueString(this.join_message, entry_resolvable);
+            const join_msg = await this.interpolateQueueString(this.join_message, entry_resolvable);
             return join_msg ?? default_join_message;
         }
         else {

--- a/src/models/rooms.ts
+++ b/src/models/rooms.ts
@@ -1,11 +1,11 @@
 import mongoose from "mongoose";
 import { EventDate } from "../../typings";
 import { VoiceChannelEvent, VoiceChannelEventType } from "./events";
-import { UserModel } from "./users";
-import { sessionRole } from "./sessions";
+import {sessionRole} from "./sessions";
 import { Snowflake, User } from "discord.js";
 import { filterAsync } from "../utils/general";
-import { ArraySubDocumentType, DocumentType, ReturnModelType, getModelForClass, prop } from "@typegoose/typegoose";
+import { ArraySubDocumentType, DocumentType, ReturnModelType, prop } from "@typegoose/typegoose";
+import {RoomModel, UserModel} from "./models";
 
 export class Room {
     /**
@@ -173,8 +173,3 @@ export class Room {
     }
 }
 
-export const RoomModel = getModelForClass(Room, {
-    schemaOptions: {
-        autoCreate: true,
-    },
-});

--- a/src/models/sessions.ts
+++ b/src/models/sessions.ts
@@ -1,5 +1,5 @@
-import { RoomModel } from "./rooms";
-import { DocumentType, getModelForClass, prop, mongoose } from "@typegoose/typegoose";
+import { DocumentType, prop, mongoose } from "@typegoose/typegoose";
+import {RoomModel} from "./models"
 export enum sessionRole {
     "participant" = "participant",
     "coach" = "coach",
@@ -75,8 +75,3 @@ export class Session {
     }
 }
 
-export const SessionModel = getModelForClass(Session, {
-    schemaOptions: {
-        autoCreate: true,
-    },
-});

--- a/src/models/slash_command_settings.ts
+++ b/src/models/slash_command_settings.ts
@@ -1,6 +1,6 @@
 import { SlashCommandPermission } from "./slash_command_permission";
 import { PermissionResolvable } from "discord.js";
-import { ArraySubDocumentType, getModelForClass, prop, mongoose } from "@typegoose/typegoose";
+import { ArraySubDocumentType, prop, mongoose } from "@typegoose/typegoose";
 export class SlashCommandSettings {
     /**
      * The original Command name used to retrieve it from the event handler
@@ -44,8 +44,3 @@ export class SlashCommandSettings {
     }
 }
 
-export const SlashCommandSettingsModel = getModelForClass(SlashCommandSettings, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/text_channels.ts
+++ b/src/models/text_channels.ts
@@ -1,5 +1,5 @@
 import { ChannelType, TextChannelType } from "discord.js";
-import { getModelForClass, prop } from "@typegoose/typegoose";
+import { prop } from "@typegoose/typegoose";
 
 /**
  * Database Representation of a Discord Channel
@@ -57,8 +57,3 @@ export class TextChannel implements Channel {
 
 }
 
-export const TextChannelModel = getModelForClass(TextChannel, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/users.ts
+++ b/src/models/users.ts
@@ -1,7 +1,8 @@
 // import mongoose from 'mongoose';
 import mongoose from "mongoose";
-import  { Session, SessionModel, sessionRole } from "./sessions";
-import { DocumentType, Ref, getModelForClass, prop } from "@typegoose/typegoose";
+import  { Session, sessionRole } from "./sessions";
+import { SessionModel } from "./models"
+import { DocumentType, Ref, prop } from "@typegoose/typegoose";
 import { DBRole } from "./bot_roles";
 
 // TODO: User Settings, Other User Stuff
@@ -83,8 +84,4 @@ export class User {
     }
 }
 
-export const UserModel = getModelForClass(User, {
-    schemaOptions: {
-        autoCreate: true,
-    },
-});
+

--- a/src/models/voice_channel_spawner.ts
+++ b/src/models/voice_channel_spawner.ts
@@ -1,5 +1,5 @@
 import { PermissionOverwriteData } from "./permission_overwrite_data";
-import { prop, mongoose, getModelForClass, ArraySubDocumentType } from "@typegoose/typegoose";
+import { prop, mongoose, ArraySubDocumentType } from "@typegoose/typegoose";
 
 export class VoiceChannelSpawner {
     /**
@@ -44,8 +44,3 @@ export class VoiceChannelSpawner {
         parent?: string;
 }
 
-export const VoiceChannelSpawnerModel = getModelForClass(VoiceChannelSpawner, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/voice_channels.ts
+++ b/src/models/voice_channels.ts
@@ -1,4 +1,4 @@
-import { SubDocumentType, getModelForClass } from "@typegoose/typegoose";
+import { SubDocumentType } from "@typegoose/typegoose";
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import { Channel } from "./text_channels";
 import { VoiceChannelSpawner } from "./voice_channel_spawner";
@@ -119,8 +119,3 @@ export class VoiceChannel implements Channel {
     }
 }
 
-export const VoiceChannelModel = getModelForClass(VoiceChannel, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/models/week_timestamp.ts
+++ b/src/models/week_timestamp.ts
@@ -1,4 +1,4 @@
-import { getModelForClass, prop } from "@typegoose/typegoose";
+import { prop } from "@typegoose/typegoose";
 
 export enum Weekday {
     /**
@@ -146,8 +146,3 @@ export class WeekTimestamp {
     }
 }
 
-export const WeekTimestampModel = getModelForClass(WeekTimestamp, {
-    schemaOptions: {
-        autoCreate: false,
-    },
-});

--- a/src/service/queue-info/QueueInfoService.ts
+++ b/src/service/queue-info/QueueInfoService.ts
@@ -1,11 +1,12 @@
-import { Guild as GuildDB, GuildModel } from "../../models/guilds";
 import { Guild, GuildChannel, TextChannel, TextChannel as DiscordTextChannel, User } from "discord.js";
 import { UserError } from "../error/UserError";
 import { QueueEventType } from "../../models/events";
 import { ArraySubDocumentType, DocumentType } from "@typegoose/typegoose";
 import { Queue } from "../../models/queues";
 import { InternalRoles } from "../../models/bot_roles";
-import { Session, SessionModel } from "../../models/sessions";
+import { Session } from "../../models/sessions";
+import {QueueService} from "../queue/QueueService";
+import {GuildModel, SessionModel} from "../../models/models";
 
 /**
  * A Service to handle all queue info related stuff
@@ -44,7 +45,7 @@ export default class QueueInfoService {
         this.validateIsTextChannel(channel);
 
         const guildData = await this.fetchGuildData(g.id);
-        const queueData = this.findQueueData(guildData, queueName);
+        const queueData = QueueService.findQueueData(guildData, queueName);
 
         const events: QueueEventType[] = this.validateAndConvertEventStrings(eventStrings);
         await this.updateQueueInfoChannels(queueData, channel.id, events);
@@ -61,7 +62,7 @@ export default class QueueInfoService {
         this.validateIsTextChannel(channel);
 
         const guildData = await this.fetchGuildData(g.id);
-        const queueData = this.findQueueData(guildData, queueName);
+        const queueData = QueueService.findQueueData(guildData, queueName);
 
         const isRemoved = this.removeChannelFromQueueInfo(queueData, channel.id);
 
@@ -134,20 +135,6 @@ export default class QueueInfoService {
             throw new UserError("Guild Data Could not be found.");
         }
         return guildData;
-    }
-
-    /**
-     * finds the queue data for the given queue name
-     * @param guildData the guild data to search in
-     * @param queueName the name of the queue
-     * @returns the queue data
-     */
-    private static findQueueData(guildData: DocumentType<GuildDB>, queueName: string) {
-        const queueData = guildData.queues.find(x => x.name === queueName);
-        if (!queueData) {
-            throw new UserError("Could not find Queue.");
-        }
-        return queueData;
     }
 
     /**

--- a/src/service/queue/QueueService.ts
+++ b/src/service/queue/QueueService.ts
@@ -1,0 +1,63 @@
+import { Guild as GuildDB } from "../../models/guilds";
+import { Guild} from "discord.js";
+import { UserError } from "../error/UserError";
+import { DocumentType } from "@typegoose/typegoose";
+import { GuildModel } from "../../models/models";
+
+
+
+export class QueueService {
+
+
+    /**
+     * sets the join Message of the given queue
+     * @param g discord guild of the queue
+     * @param queueName name of the queue
+     * @param joinMessage join message to set
+     */
+    public static async setJoinMessage(g: Guild, queueName: string, joinMessage: string) {
+        const guildData = await GuildModel.findById(g.id);
+        if (!guildData) {
+            throw new UserError("Guild Data Could not be found.");
+        }
+
+        const queueData = this.findQueueData(guildData, queueName)
+        queueData.join_message = joinMessage
+
+        await guildData.save()
+    }
+
+    /**
+     * sets the leave Messag of the given queue
+     * @param g discord guild of the queue
+     * @param queueName name of the queue
+     * @param leaveMessage leave message to set
+     */
+    public static async setLeaveMessage(g: Guild, queueName: string, leaveMessage: string) {
+        const guildData = await GuildModel.findById(g.id);
+        if (!guildData) {
+            throw new UserError("Guild Data Could not be found.");
+        }
+
+        const queueData = this.findQueueData(guildData, queueName)
+        queueData.leave_message = leaveMessage
+
+        await guildData.save()
+    }
+
+    /**
+     * finds the queue data for the given queue name
+     * @param guildData the guild data to search in
+     * @param queueName the name of the queue
+     * @returns the queue data
+     * @throws UserError if the queue data can not be found
+     */
+    public static findQueueData(guildData: DocumentType<GuildDB>, queueName: string) {
+        const queueData = guildData.queues.find(x => x.name === queueName);
+        if (!queueData) {
+            throw new UserError("Could not find Queue.");
+        }
+        return queueData;
+    }
+
+}

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,5 +1,5 @@
-import { ConfigHandler } from "./../handlers/configHandler";
-import { DBRole, InternalRoles, RoleScopes } from "./../models/bot_roles";
+import { ConfigHandler } from "../handlers/configHandler";
+import { DBRole, InternalRoles, RoleScopes } from "../models/bot_roles";
 import ChannelType, {
     CommandInteraction,
     Guild as DiscrodGuild,
@@ -15,14 +15,13 @@ import ChannelType, {
 } from "discord.js";
 import moment from "moment";
 import { Command, StringReplacements } from "../../typings";
-import { GuildModel } from "../models/guilds";
 import { Bot } from "../bot";
-import { UserModel } from "../models/users";
 import * as cryptojs from "crypto-js";
 import { ArraySubDocumentType, DocumentType } from "@typegoose/typegoose";
 import { Queue } from "../models/queues";
 import QueueInfoService from "../service/queue-info/QueueInfoService";
 import { QueueEventType } from "../models/events";
+import {GuildModel, UserModel} from "../models/models";
 
 /**
  * Checks if a given Variable is an array[] with at least a length of one or not

--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -1,10 +1,10 @@
 import { FilterOutFunctionKeys } from "@typegoose/typegoose/lib/types";
 import { ChannelType, Guild, GuildMember, GuildPremiumTier, OverwriteData } from "discord.js";
 import { Bot } from "../bot";
-import { GuildModel } from "../models/guilds";
 import { VoiceChannel } from "../models/voice_channels";
 import { VoiceChannelSpawner } from "../models/voice_channel_spawner";
 import { mongoose } from "@typegoose/typegoose";
+import {GuildModel} from "../models/models";
 
 /**
  * Creates a managed Voice Channel Based on a Voice Channel Spawner


### PR DESCRIPTION
added new commands to set the join and leave message of a queue
/admin setjoinmessage message queue
/admin setleavemessage message queue

added closing_time and acitve_coaches as parameters for the queue string

Refactorment: 
Because of the circular dependency between the UserModel and SessionModel using the SessionModel in Queue was throwing an error: RefOptionIsUndefinedError: Prop-Option "ref"'s value is "null" or "undefined" for "User.sessions" [E005]

This is a known Typegoose Error which is mentioned here: https://typegoose.github.io/typegoose/docs/guides/advanced/reference-other-classes/#common-problems

I applied the recommended solution to solve this issue by providing a central models.ts file in which all models are loaded centrally. Thus all imports have to be adapted (thats why so many files have been changed : - ) )

